### PR TITLE
Added Short Fuse, Pass the Ammo and Bring Your Cop To Work Day

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,19 @@ For achievements that required 4 different masks, this number now scales with nu
 * any future achievement or trophy that will require 4 different masks
 
 Other achievements:
-* Megalo-Mania - reduced amount of combined stacks required to 390 for 1, 780 for 2 and 1170 for 3 players
+* Megalo-Mania (mad_5) - reduced amount of combined stacks required to 390 for 1, 780 for 2 and 1170 for 3 players
 * C-40 (cac_15) - reduced amount of mines required to 14 for 1 and 28 for 2 players
 * Short Fuse (short_fuse) - reduced amount of bags required to 3 for 1 and 6 for 2 players
 * Pass the Ammo (spa_6) - reduced amount of ammo bags required to 2 for 1, 4 for 2 and 6 for 3 players
-
-Achievements that I did not found a way to mod:
-* [Tag, You're It! (fort_3)](https://github.com/Cigaras/Payday-2-Solo-Achievements/issues/1)
-* Quick Draw (cac_9)
+* Bring Your Cop To Work Day (ovk_9) - reduced amount of converted cops required to 1 for 1, 2 for 2 and 3 for 3 players
 
 Achievements and trophies not affected by this mod:
 * Failed Assassination trophy - equip Your bots with sniper rifles
 * Long Fellow trophy - use [Forklift Capacity](https://github.com/Cigaras/Payday-2-Forklift-Capacity) mod to increases forklift capacity up to 8 to be able to transport all required bags in one go
 * Sewer Rats - use [Monkeepers](http://paydaymods.com/mods/581/MKP) mod for bots to carry bags and [Keepers](http://paydaymods.com/mods/102/KPR) mod for Jokers to defend bags
 * OVERDRILL - use [Forced Overdrill](https://github.com/Cigaras/Payday-2-Forced-Overdrill) mod to activate Overdrill mode with a key bind instead of positioning 4 players around the vault
+* Tag, You're It! - it's a race, just go on multiplayer and do it
+* Quick Draw - not easy, check [this video](https://www.youtube.com/watch?v=wtWzdDBH4YE)
 
 Credits:
 * Author: [Valdas V.](https://valdasv.lt)

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ For achievements that required 4 different masks, this number now scales with nu
 Other achievements:
 * Megalo-Mania - reduced amount of combined stacks required to 390 for 1, 780 for 2 and 1170 for 3 players
 * C-40 (cac_15) - reduced amount of mines required to 14 for 1 and 28 for 2 players
+* Short Fuse (short_fuse) - reduced amount of bags required to 3 for 1 and 6 for 2 players
+* Pass the Ammo (spa_6) - reduced amount of ammo bags required to 2 for 1, 4 for 2 and 6 for 3 players
 
 Achievements that I did not found a way to mod:
-* Short Fuse (short_fuse)
-* Pass the Ammo (spa_6)
 * [Tag, You're It! (fort_3)](https://github.com/Cigaras/Payday-2-Solo-Achievements/issues/1)
 * Quick Draw (cac_9)
 

--- a/Solo Achievements/lua/coreelementcounter.lua
+++ b/Solo Achievements/lua/coreelementcounter.lua
@@ -1,16 +1,15 @@
 core:module("CoreElementCounter")
 
-Hooks:PostHook(ElementCounter, "_check_triggers", "ElementCounter__check_triggers_sa", function(self, type)
+Hooks:PreHook(ElementCounter, "_check_triggers", "ElementCounter__check_triggers_sa", function (self, type)
 	if not self._triggers[type] then
 		return
 	end
 
-	if managers.job:current_level_id() == "alex_3" and self._editor_name == "7bagsSecured" then
+	if managers.job:current_level_id() == "alex_3" and tostring(self:id()) == "100423" then -- 7bagsSecured
 		--Short Fuse
 		local num_players = managers.network:session():amount_of_players()
 		local num_bags = math.min(7, 3*num_players)
-		if type ~= "value" or self._values.counter_target == num_bags then
-			self._triggers[type][100827].callback()
-		end
+
+		self._triggers[type][100827].amount = num_bags
 	end
 end)

--- a/Solo Achievements/lua/coreelementcounter.lua
+++ b/Solo Achievements/lua/coreelementcounter.lua
@@ -1,0 +1,16 @@
+core:module("CoreElementCounter")
+
+Hooks:PostHook(ElementCounter, "_check_triggers", "ElementCounter__check_triggers_sa", function(self, type)
+	if not self._triggers[type] then
+		return
+	end
+
+	if managers.job:current_level_id() == "alex_3" and self._editor_name == "7bagsSecured" then
+		--Short Fuse
+		local num_players = managers.network:session():amount_of_players()
+		local num_bags = math.min(7, 3*num_players)
+		if type ~= "value" or self._values.counter_target == num_bags then
+			self._triggers[type][100827].callback()
+		end
+	end
+end)

--- a/Solo Achievements/lua/coremissionmanager.lua
+++ b/Solo Achievements/lua/coremissionmanager.lua
@@ -1,0 +1,15 @@
+core:module("CoreMissionManager")
+
+Hooks:PreHook(MissionManager, "_add_script", "MissionManager__add_script_sa", function(self, data)
+	--Pass the Ammo
+	if managers.job:current_level_id() ~= "spa" then
+		return
+	end
+
+	for k, v in pairs(data.elements) do
+		if v.editor_name == "logic_counter_012" then
+			v.values.counter_target = 2 + 2 * managers.network:session():amount_of_players()
+			return
+		end
+	end
+end)

--- a/Solo Achievements/lua/coremissionmanager.lua
+++ b/Solo Achievements/lua/coremissionmanager.lua
@@ -1,15 +1,15 @@
 core:module("CoreMissionManager")
 
-Hooks:PreHook(MissionManager, "_add_script", "MissionManager__add_script_sa", function(self, data)
+Hooks:PreHook(MissionManager, "_add_script", "MissionManager__add_script_sa", function (self, data)
 	--Pass the Ammo
 	if managers.job:current_level_id() ~= "spa" then
 		return
 	end
 
 	for k, v in pairs(data.elements) do
-		if v.editor_name == "logic_counter_012" then
+		if tostring(v.id) == "102000" then -- logic_counter_012
 			v.values.counter_target = 2 + 2 * managers.network:session():amount_of_players()
-			return
+			break
 		end
 	end
 end)

--- a/Solo Achievements/lua/groupaistatebase.lua
+++ b/Solo Achievements/lua/groupaistatebase.lua
@@ -1,0 +1,4 @@
+Hooks:PreHook(GroupAIStateBase, "check_converted_achievements", "GroupAIStateBase_check_converted_achievements_sa", function (self)
+	-- Bring Your Cop To Work Day
+	tweak_data.achievement.convert_enemies.double_trouble.count = managers.network:session():amount_of_players()
+end)

--- a/Solo Achievements/mod.txt
+++ b/Solo Achievements/mod.txt
@@ -12,20 +12,28 @@
 	],
 	"hooks": [
 		{
-			"hook_id": "lib/tweak_data/achievementstweakdata",
-			"script_path": "lua/achievementstweakdata.lua"
+			"hook_id": "core/lib/managers/mission/coreelementcounter",
+			"script_path": "lua/coreelementcounter.lua"
+		},
+		{
+			"hook_id": "core/lib/managers/mission/coremissionmanager",
+			"script_path": "lua/coremissionmanager.lua"
 		},
 		{
 			"hook_id": "lib/managers/achievement/cac_customachievements",
 			"script_path": "lua/cac_customachievements.lua"
 		},
 		{
+			"hook_id": "lib/managers/playermanager",
+			"script_path": "lua/playermanager.lua"
+		},
+		{
 			"hook_id": "lib/states/missionendstate",
 			"script_path": "lua/missionendstate.lua"
 		},
 		{
-			"hook_id": "lib/managers/playermanager",
-			"script_path": "lua/playermanager.lua"
+			"hook_id": "lib/tweak_data/achievementstweakdata",
+			"script_path": "lua/achievementstweakdata.lua"
 		}
 	]
 }

--- a/Solo Achievements/mod.txt
+++ b/Solo Achievements/mod.txt
@@ -24,6 +24,10 @@
 			"script_path": "lua/cac_customachievements.lua"
 		},
 		{
+			"hook_id": "lib/managers/group_ai_states/groupaistatebase",
+			"script_path": "lua/groupaistatebase.lua"
+		},
+		{
 			"hook_id": "lib/managers/playermanager",
 			"script_path": "lua/playermanager.lua"
 		},

--- a/Solo Achievements/readme.txt
+++ b/Solo Achievements/readme.txt
@@ -28,20 +28,19 @@ For achievements that required 4 different masks, this number now scales with nu
 * any future achievement or trophy that will require 4 different masks
 
 Other achievements:
-* Megalo-Mania - reduced amount of combined stacks required to 390 for 1, 780 for 2 and 1170 for 3 players
+* Megalo-Mania (mad_5) - reduced amount of combined stacks required to 390 for 1, 780 for 2 and 1170 for 3 players
 * C-40 (cac_15) - reduced amount of mines required to 14 for 1 and 28 for 2 players
 * Short Fuse (short_fuse) - reduced amount of bags required to 3 for 1 and 6 for 2 players
 * Pass the Ammo (spa_6) - reduced amount of ammo bags required to 2 for 1, 4 for 2 and 6 for 3 players
-
-Achievements that I did not found a way to mod:
-* Tag, You're It! (fort_3)
-* Quick Draw (cac_9)
+* Bring Your Cop To Work Day (ovk_9) - reduced amount of converted cops required to 1 for 1, 2 for 2 and 3 for 3 players
 
 Achievements and trophies not affected by this mod:
 * Failed Assassination trophy - equip Your bots with sniper rifles
 * Long Fellow trophy - use Forklift Capacity mod to increases forklift capacity up to 8 to be able to transport all required bags in one go
 * Sewer Rats - use Monkeepers mod for bots to carry bags and Keepers mod for Jokers to defend bags
 * OVERDRILL	- use Forced Overdrill mod to activate Overdrill mode with a key bind instead of positioning 4 players around the vault
+* Tag, You're It! - it's a race, just go on multiplayer and do it
+* Quick Draw - not easy, check [this video](https://www.youtube.com/watch?v=wtWzdDBH4YE)
 
 Credits:
 * Author: Valdas V.

--- a/Solo Achievements/readme.txt
+++ b/Solo Achievements/readme.txt
@@ -30,10 +30,10 @@ For achievements that required 4 different masks, this number now scales with nu
 Other achievements:
 * Megalo-Mania - reduced amount of combined stacks required to 390 for 1, 780 for 2 and 1170 for 3 players
 * C-40 (cac_15) - reduced amount of mines required to 14 for 1 and 28 for 2 players
+* Short Fuse (short_fuse) - reduced amount of bags required to 3 for 1 and 6 for 2 players
+* Pass the Ammo (spa_6) - reduced amount of ammo bags required to 2 for 1, 4 for 2 and 6 for 3 players
 
 Achievements that I did not found a way to mod:
-* Short Fuse (short_fuse)
-* Pass the Ammo (spa_6)
 * Tag, You're It! (fort_3)
 * Quick Draw (cac_9)
 


### PR DESCRIPTION
Made the above achievements possible to solo the following way:

* Short Fuse (short_fuse) - it's now 3 bags for 1 and 2 players (for 3 and 4 for it's still 7)
* Pass the Ammo (spa_6) - it's now 2 bags for each player
* Bring Your Cop To Work Day (ovk_9) - it's now the number of players (should this be soloable? lol)

Changed the README on the following achievements:

- Quick draw - It's already soloable, added the video for it
- Tag, You're It! - I don't think it should be done solo, it's a race lol